### PR TITLE
Renamed CoreDataKit class to CDK

### DIFF
--- a/CoreDataKit.xcodeproj/project.pbxproj
+++ b/CoreDataKit.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		D5C6C63F19EEC6D60035BFFF /* NSManagedObjectContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C6C63E19EEC6D60035BFFF /* NSManagedObjectContextTests.swift */; };
 		D5D7C6C81958B8CF0048B576 /* CoreDataKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5D7C6BC1958B8CF0048B576 /* CoreDataKit.framework */; };
 		D5D7C6CF1958B8CF0048B576 /* CoreDataKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D7C6CE1958B8CF0048B576 /* CoreDataKitTests.swift */; };
-		D5D7C6D91958B9300048B576 /* CoreDataKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D7C6D81958B9300048B576 /* CoreDataKit.swift */; };
+		D5D7C6D91958B9300048B576 /* CDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D7C6D81958B9300048B576 /* CDK.swift */; };
 		D5D8E81C1A0363A300991FEA /* ManagedObjectObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D8E81B1A0363A300991FEA /* ManagedObjectObserver.swift */; };
 		D5EDACE319EF950B00FAC712 /* NSPersistentStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EDACE219EF950B00FAC712 /* NSPersistentStoreTests.swift */; };
 		D5FE0FBE19F28340008DC1ED /* Employees.json in Resources */ = {isa = PBXBuildFile; fileRef = D5FE0FBD19F28340008DC1ED /* Employees.json */; };
@@ -98,7 +98,7 @@
 		D5D7C6C71958B8CF0048B576 /* CoreDataKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CoreDataKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5D7C6CD1958B8CF0048B576 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D5D7C6CE1958B8CF0048B576 /* CoreDataKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataKitTests.swift; sourceTree = "<group>"; };
-		D5D7C6D81958B9300048B576 /* CoreDataKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataKit.swift; sourceTree = "<group>"; };
+		D5D7C6D81958B9300048B576 /* CDK.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CDK.swift; sourceTree = "<group>"; };
 		D5D8E81B1A0363A300991FEA /* ManagedObjectObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManagedObjectObserver.swift; sourceTree = "<group>"; };
 		D5EDACE219EF950B00FAC712 /* NSPersistentStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSPersistentStoreTests.swift; sourceTree = "<group>"; };
 		D5FE0FBD19F28340008DC1ED /* Employees.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Employees.json; sourceTree = "<group>"; };
@@ -187,7 +187,7 @@
 			isa = PBXGroup;
 			children = (
 				D595F68619EF0ED800D73790 /* Types.swift */,
-				D5D7C6D81958B9300048B576 /* CoreDataKit.swift */,
+				D5D7C6D81958B9300048B576 /* CDK.swift */,
 				D595F68419EF0EA100D73790 /* CoreDataStack.swift */,
 				D5D8E81B1A0363A300991FEA /* ManagedObjectObserver.swift */,
 				D5253DA419F1491E00E8B4AF /* NamedManagedObject.swift */,
@@ -364,7 +364,7 @@
 				D595F68519EF0EA100D73790 /* CoreDataStack.swift in Sources */,
 				D5253DA119F12F1C00E8B4AF /* NSManagedObject+Importing.swift in Sources */,
 				D5D8E81C1A0363A300991FEA /* ManagedObjectObserver.swift in Sources */,
-				D5D7C6D91958B9300048B576 /* CoreDataKit.swift in Sources */,
+				D5D7C6D91958B9300048B576 /* CDK.swift in Sources */,
 				D55152D1196A739500857453 /* NSPersistentStore.swift in Sources */,
 				D5BD629F1A01587800098343 /* TableViewFetchedResultsControllerDelegate.swift in Sources */,
 				D540D82C19FE2A5E00769B84 /* Types+Importing.swift in Sources */,

--- a/CoreDataKit/CDK.swift
+++ b/CoreDataKit/CDK.swift
@@ -1,5 +1,5 @@
 //
-//  CoreDataKit.swift
+//  CDK.swift
 //  CoreDataKit
 //
 //  Created by Mathijs Kadijk on 23-06-14.
@@ -18,9 +18,9 @@ public enum LogLevel {
 public typealias Logger = (LogLevel, String) -> Void
 
 /**
-`CoreDataKit` helps with setup of the CoreData stack
+`CDK` helps with setup of the CoreData stack
 */
-public class CoreDataKit : NSObject
+public class CDK : NSObject
 {
     private struct Holder {
         static var sharedStack: CoreDataStack?
@@ -28,7 +28,7 @@ public class CoreDataKit : NSObject
     }
 
     /**
-    Property to hold a shared instance of CoreDataKit, all the convenience class properties access and unwrap this shared instance. So make sure to set the shared instance before doing anything else.
+    Property to hold a shared instance of CoreDataStack, all the convenience class properties access and unwrap this shared instance. So make sure to set the shared instance before doing anything else.
     
     :discussion: This is the only property you have to set to setup CoreDataKit, changing the shared instace is not supported.
     */

--- a/CoreDataKit/CoreDataStack.swift
+++ b/CoreDataKit/CoreDataStack.swift
@@ -63,11 +63,11 @@ public class CoreDataStack: NSObject {
     Dumps some debug info about this stack to the console
     */
     public func dumpStack() {
-        CoreDataKit.sharedLogger(.DEBUG, "Stores: \(persistentStoreCoordinator.persistentStores)")
-        CoreDataKit.sharedLogger(.DEBUG, " - Store coordinator: \(persistentStoreCoordinator.debugDescription)")
-        CoreDataKit.sharedLogger(.DEBUG, " |- Root context: \(rootContext.debugDescription)")
-        CoreDataKit.sharedLogger(.DEBUG, "  |- Main thread context: \(mainThreadContext.debugDescription)")
-        CoreDataKit.sharedLogger(.DEBUG, "  |- Background context: \(backgroundContext.debugDescription)")
+        CDK.sharedLogger(.DEBUG, "Stores: \(persistentStoreCoordinator.persistentStores)")
+        CDK.sharedLogger(.DEBUG, " - Store coordinator: \(persistentStoreCoordinator.debugDescription)")
+        CDK.sharedLogger(.DEBUG, " |- Root context: \(rootContext.debugDescription)")
+        CDK.sharedLogger(.DEBUG, "  |- Main thread context: \(mainThreadContext.debugDescription)")
+        CDK.sharedLogger(.DEBUG, "  |- Background context: \(backgroundContext.debugDescription)")
     }
 
 // MARK: Notification observers

--- a/CoreDataKit/Importing/CoreDataStack+Importing.swift
+++ b/CoreDataKit/Importing/CoreDataStack+Importing.swift
@@ -16,16 +16,16 @@ extension CoreDataStack {
         let entityUserInfoKeys = [IdentifierUserInfoKey]
 
         for (entityName, _entity) in persistentStoreCoordinator.managedObjectModel.entitiesByName {
-            CoreDataKit.sharedLogger(.DEBUG, " ")
+            CDK.sharedLogger(.DEBUG, " ")
 
             let entity = _entity as NSEntityDescription
-            CoreDataKit.sharedLogger(.DEBUG, "\(entityName):")
+            CDK.sharedLogger(.DEBUG, "\(entityName):")
 
             for (_key, value) in entity.userInfo! {
                 let key = _key as String
 
                 if !contains(entityUserInfoKeys, key) {
-                    CoreDataKit.sharedLogger(.DEBUG, "  ⚠ \(key) → \(value)")
+                    CDK.sharedLogger(.DEBUG, "  ⚠ \(key) → \(value)")
                 }
             }
 
@@ -59,7 +59,7 @@ extension CoreDataStack {
         let relationshipType = (property as? NSRelationshipDescription)?.relationType.rawValue
         let relationshipTypeDescription = relationshipType == nil ? "" : " → \(relationshipType!)"
 
-        CoreDataKit.sharedLogger(.DEBUG, "\(identifying)\(indexed)\(property.name)\(optional) → \(property.mappings)\(relationshipTypeDescription)")
+        CDK.sharedLogger(.DEBUG, "\(identifying)\(indexed)\(property.name)\(optional) → \(property.mappings)\(relationshipTypeDescription)")
 
         for (_key, value) in property.userInfo! {
             let key = _key as String
@@ -67,7 +67,7 @@ extension CoreDataStack {
             if !contains(propertyUserInfoKeys, key) {
                 if (property is NSAttributeDescription && !contains(attributeUserInfoKeys, key)) ||
                     (property is NSRelationshipDescription && !contains(relationshipUserInfoKeys, key)) {
-                    CoreDataKit.sharedLogger(.DEBUG, "  ⚠ \(key) → \(value)")
+                    CDK.sharedLogger(.DEBUG, "  ⚠ \(key) → \(value)")
                 }
             }
         }

--- a/CoreDataKit/Importing/NSPropertyDescription+Importing.swift
+++ b/CoreDataKit/Importing/NSPropertyDescription+Importing.swift
@@ -17,7 +17,7 @@ extension NSPropertyDescription
             if let strategy = MapStrategy(rawValue: mappingStrategyString) {
                 return strategy
             } else {
-                CoreDataKit.sharedLogger(.ERROR, "Unsupported \(MappingUserInfoKey) given for \(entity.name).\(name), falling back to \(fallbackStrategy.rawValue) strategy")
+                CDK.sharedLogger(.ERROR, "Unsupported \(MappingUserInfoKey) given for \(entity.name).\(name), falling back to \(fallbackStrategy.rawValue) strategy")
                 return fallbackStrategy
             }
         }
@@ -49,7 +49,7 @@ extension NSPropertyDescription
                     _mappings.append(numberedMapping)
 
                     if i == MaxNumberedMappings+1 {
-                        CoreDataKit.sharedLogger(.WARN, "Only mappings up to \(MappingUserInfoKey).\(MaxNumberedMappings) mappings are supported all others are ignored, you defined more for \(entity.name).\(name)")
+                        CDK.sharedLogger(.WARN, "Only mappings up to \(MappingUserInfoKey).\(MaxNumberedMappings) mappings are supported all others are ignored, you defined more for \(entity.name).\(name)")
                     }
                 }
             }

--- a/CoreDataKit/Importing/NSRelationshipDescription+Importing.swift
+++ b/CoreDataKit/Importing/NSRelationshipDescription+Importing.swift
@@ -18,7 +18,7 @@ extension NSRelationshipDescription {
             if let relationType = RelationType(rawValue: relationTypeString) {
                 return relationType
             } else {
-                CoreDataKit.sharedLogger(.ERROR, "Unsupported \(RelationTypeUserInfoKey) given for \(entity.name).\(name), falling back to \(fallbackRelationType.rawValue) relation type")
+                CDK.sharedLogger(.ERROR, "Unsupported \(RelationTypeUserInfoKey) given for \(entity.name).\(name), falling back to \(fallbackRelationType.rawValue) relation type")
                 return fallbackRelationType
             }
         }

--- a/CoreDataKit/NSPersistentStoreCoordinator.swift
+++ b/CoreDataKit/NSPersistentStoreCoordinator.swift
@@ -99,7 +99,7 @@ extension NSPersistentStoreCoordinator
             // Check for version mismatch
             if (deleteOnMismatch && NSCocoaErrorDomain == error.domain && (NSPersistentStoreIncompatibleVersionHashError == error.code || NSMigrationMissingSourceModelError == error.code)) {
 
-                CoreDataKit.sharedLogger(.WARN, "Model mismatch, removing persistent store...")
+                CDK.sharedLogger(.WARN, "Model mismatch, removing persistent store...")
                 if let urlString = URL.absoluteString {
                     let shmFile = urlString.stringByAppendingString("-shm")
                     let walFile = urlString.stringByAppendingString("-wal")
@@ -109,20 +109,20 @@ extension NSPersistentStoreCoordinator
                 }
 
                 if let error = addStore().error() {
-                    CoreDataKit.sharedLogger(.ERROR, "Failed to add SQLite persistent store: \(error)")
+                    CDK.sharedLogger(.ERROR, "Failed to add SQLite persistent store: \(error)")
                 }
             }
             // Workaround for "Migration failed after first pass" error
             else if automigrating {
-                CoreDataKit.sharedLogger(.WARN, "[CoreDataKit] Applying workaround for 'Migration failed after first pass' bug, retrying...")
+                CDK.sharedLogger(.WARN, "[CoreDataKit] Applying workaround for 'Migration failed after first pass' bug, retrying...")
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(NSEC_PER_SEC) / 2), dispatch_get_main_queue()) {
                     if let error = addStore().error() {
-                        CoreDataKit.sharedLogger(.ERROR, "Failed to add SQLite persistent store: \(error)")
+                        CDK.sharedLogger(.ERROR, "Failed to add SQLite persistent store: \(error)")
                     }
                 }
             }
             else {
-                CoreDataKit.sharedLogger(.ERROR, "Failed to add SQLite persistent store: \(error)")
+                CDK.sharedLogger(.ERROR, "Failed to add SQLite persistent store: \(error)")
             }
         }
     }

--- a/CoreDataKitTests/CoreDataKitTests.swift
+++ b/CoreDataKitTests/CoreDataKitTests.swift
@@ -12,20 +12,20 @@ import CoreDataKit
 
 class CoreDataKitTests: TestCase {
     func testPersistentStoreCoordinator() {
-        XCTAssertEqual(CoreDataKit.persistentStoreCoordinator, CoreDataKit.sharedStack!.persistentStoreCoordinator, "Incorrect persistent coordinator")
+        XCTAssertEqual(CDK.persistentStoreCoordinator, CDK.sharedStack!.persistentStoreCoordinator, "Incorrect persistent coordinator")
     }
 
     func testBackgroundContext() {
-        XCTAssertNotNil(CoreDataKit.backgroundContext.persistentStoreCoordinator, "Missing persistent coordinator")
-        XCTAssertEqual(CoreDataKit.backgroundContext.persistentStoreCoordinator!, CoreDataKit.persistentStoreCoordinator, "Incorrect persistent coordinator")
-        XCTAssertNotNil(CoreDataKit.backgroundContext.parentContext, "Missing parent context")
-        XCTAssertEqual(CoreDataKit.backgroundContext.parentContext!, CoreDataKit.sharedStack!.rootContext, "Incorrect parent context")
+        XCTAssertNotNil(CDK.backgroundContext.persistentStoreCoordinator, "Missing persistent coordinator")
+        XCTAssertEqual(CDK.backgroundContext.persistentStoreCoordinator!, CDK.persistentStoreCoordinator, "Incorrect persistent coordinator")
+        XCTAssertNotNil(CDK.backgroundContext.parentContext, "Missing parent context")
+        XCTAssertEqual(CDK.backgroundContext.parentContext!, CDK.sharedStack!.rootContext, "Incorrect parent context")
     }
 
     func testMainThreadContext() {
-        XCTAssertNotNil(CoreDataKit.mainThreadContext.persistentStoreCoordinator, "Missing persistent coordinator")
-        XCTAssertEqual(CoreDataKit.mainThreadContext.persistentStoreCoordinator!, CoreDataKit.persistentStoreCoordinator, "Incorrect persistent coordinator")
-        XCTAssertNotNil(CoreDataKit.mainThreadContext.parentContext, "Missing parent context")
-        XCTAssertEqual(CoreDataKit.mainThreadContext.parentContext!, CoreDataKit.sharedStack!.rootContext, "Incorrect parent context")
+        XCTAssertNotNil(CDK.mainThreadContext.persistentStoreCoordinator, "Missing persistent coordinator")
+        XCTAssertEqual(CDK.mainThreadContext.persistentStoreCoordinator!, CDK.persistentStoreCoordinator, "Incorrect persistent coordinator")
+        XCTAssertNotNil(CDK.mainThreadContext.parentContext, "Missing parent context")
+        XCTAssertEqual(CDK.mainThreadContext.parentContext!, CDK.sharedStack!.rootContext, "Incorrect parent context")
     }
 }

--- a/CoreDataKitTests/TestCase.swift
+++ b/CoreDataKitTests/TestCase.swift
@@ -25,7 +25,7 @@ class TestCase: XCTestCase {
 
         // Setup the shared stack
         dispatch_once(&Holder.token) {
-            CoreDataKit.sharedStack = self.setupCoreDataStack(managedObjectModel)
+            CDK.sharedStack = self.setupCoreDataStack(managedObjectModel)
         }
 
         // Setup the stack for this test


### PR DESCRIPTION
Using the same name for a class as well as the framework causes some problems with imports.

Since the class was only used as a namespace anyway, this changes the class name to `CDK` instead of `CoreDataKit`.