### PR TITLE
Add language identifiers to README.md code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [CocoaPods](http://cocoapods.org) is the advised way to include CoreDataKit into your project. A basic [Podfile](http://cocoapods.org/#get_started) including CoreDataKit would look like this:
 
-```
+```ruby
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 use_frameworks!
@@ -19,7 +19,7 @@ pod 'CoreDataKit', '~> 0.4'
 ## Usage
 
 The most basic and most used variant to setup a stack backed by an automigrating SQLite store is this:
-```
+```swift
 // Initialize CoreData stack
 if let persistentStoreCoordinator = NSPersistentStoreCoordinator(automigrating: true) {
   CDK.sharedStack = CoreDataStack(persistentStoreCoordinator: persistentStoreCoordinator)
@@ -27,7 +27,7 @@ if let persistentStoreCoordinator = NSPersistentStoreCoordinator(automigrating: 
 ```
 
 From here you are able to use the shared stack. For example to create and save an entity, this example performs a block an a background context, saves it to the persistent store and executes a completion handler:
-```
+```swift
 CDK.performBlockOnBackgroundContext({ context in
 	if let car = context.create(Car.self).value() {
 		car.color = "Hammerhead Silver"
@@ -49,7 +49,7 @@ CDK.performBlockOnBackgroundContext({ context in
 ### Using promises
 
 If you prefer using promises, instead of the callback style of this library, you can use the  [Promissum](https://github.com/tomlokhorst/Promissum) library with CoreDataKit. Using the [CoreDataKit+Promise](https://github.com/tomlokhorst/Promissum/blob/master/extensions/PromissumExtensions/CoreDataKit%2BPromise.swift) extension, the example from above can be rewritten as such:
-```
+```swift
 let createPromise = CDK.performBlockOnBackgroundContextPromise { context in
 	if let car = context.create(Car.self).value() {
 		car.color = "Hammerhead Silver"


### PR DESCRIPTION
Add language identifiers to code blocks in README.md to make example code more readable on project homepage.