### PR TITLE
Created a custom CoreDataKitError enum.

### DIFF
--- a/CoreDataKit/Importing/NSEntityDescription+Importing.swift
+++ b/CoreDataKit/Importing/NSEntityDescription+Importing.swift
@@ -21,13 +21,13 @@ extension NSEntityDescription
                 return identifyingAttribute
             }
 
-            let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.IdentifyingAttributeNotFound.rawValue, userInfo: [NSLocalizedDescriptionKey: "Found \(IdentifierUserInfoKey) with value '\(identifyingAttributeName)' but that isn't a valid attribute name"])
+            let error = CoreDataKitError.ImportError(description: "Found \(IdentifierUserInfoKey) with value '\(identifyingAttributeName)' but that isn't a valid attribute name")
             throw error
         } else if let superEntity = self.superentity {
             return try superEntity.identifyingAttribute()
         }
 
-        let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.IdentifyingAttributeNotFound.rawValue, userInfo: [NSLocalizedDescriptionKey: "No \(IdentifierUserInfoKey) value found on \(name)"])
+        let error = CoreDataKitError.ImportError(description: "No \(IdentifierUserInfoKey) value found on \(name)")
         throw error
     }
 }

--- a/CoreDataKit/Importing/NSManagedObject+Importing.swift
+++ b/CoreDataKit/Importing/NSManagedObject+Importing.swift
@@ -33,7 +33,7 @@ extension NSManagedObject
         }
 
         let entityName = self.entity.name ?? "nil"
-        let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.ImportCancelled.rawValue, userInfo: [NSLocalizedDescriptionKey: "Import of entity \(entityName) cancelled because shouldImport returned false"])
+        let error = CoreDataKitError.ImportCancelled(entityName: entityName)
         throw error
     }
 
@@ -84,16 +84,16 @@ extension NSManagedObject
                     try performImportRelationship(context, relationship: relationshipDescription, dictionary: dictionary)
 
                 case is NSFetchedPropertyDescription:
-                    let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.InvalidPropertyConfiguration.rawValue, userInfo: [NSLocalizedDescriptionKey: "Importing NSFetchedPropertyDescription is not supported"])
+                    let error = CoreDataKitError.ImportError(description: "Importing NSFetchedPropertyDescription is not supported")
                     throw error
 
                 default:
-                    let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.InvalidPropertyConfiguration.rawValue, userInfo: [NSLocalizedDescriptionKey: "Importing unknown subclass or no subclass of NSPropertyDescription is not supported"])
+                    let error = CoreDataKitError.ImportError(description: "Importing unknown subclass or no subclass of NSPropertyDescription is not supported")
                     throw error
                 }
             }
         } else {
-            let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.ContextNotFound.rawValue, userInfo: [NSLocalizedDescriptionKey: "Managed object not inserted in context, objects must be inserted before importing"])
+            let error = CoreDataKitError.ImportError(description: "Managed object not inserted in context, objects must be inserted before importing")
             throw error
         }
     }
@@ -124,7 +124,7 @@ extension NSManagedObject
             if let transformedValue: AnyObject = attribute.transformValue(value) {
                 setValue(transformedValue, forKeyPath: attribute.name)
             } else {
-                let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.InvalidValue.rawValue, userInfo: [NSLocalizedDescriptionKey: "Value '\(value)' could not be transformed to a value compatible with the type of \(entity.name).\(attribute.name)"])
+                let error = CoreDataKitError.ImportError(description: "Value '\(value)' could not be transformed to a value compatible with the type of \(entity.name).\(attribute.name)")
                 throw error
             }
 
@@ -157,8 +157,8 @@ extension NSManagedObject
                 try performImportEmbeddingRelationship(context, relationship: relationship, importableValue: importableValue, destinationEntity: destinationEntity)
             }
         } else {
-            let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.InvalidPropertyConfiguration.rawValue, userInfo: [NSLocalizedDescriptionKey: "Relationship \(self.entity.name).\(relationship.name) has no destination entity defined"])
-            error
+            let error = CoreDataKitError.ImportError(description: "Relationship \(self.entity.name).\(relationship.name) has no destination entity defined")
+            throw error
         }
     }
 
@@ -169,7 +169,7 @@ extension NSManagedObject
             try self.updateRelationship(context, relationship: relationship, withValue: object, deleteCurrent: false)
 
         case .Some(_ as [AnyObject]):
-            let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.UnimplementedMethod.rawValue, userInfo: [NSLocalizedDescriptionKey: "Multiple referenced / nested relationships not yet supported with relation type \(RelationType.Reference)"])
+            let error = CoreDataKitError.UnimplementedMethod(description: "Multiple referenced / nested relationships not yet supported with relation type \(RelationType.Reference)")
             throw error
 
         case let .Some(value):
@@ -191,13 +191,12 @@ extension NSManagedObject
             try destinationObject.importDictionary(value)
             try self.updateRelationship(context, relationship: relationship, withValue: destinationObject, deleteCurrent: true)
 
-
         case .Some(_ as [AnyObject]):
-            let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.UnimplementedMethod.rawValue, userInfo: [NSLocalizedDescriptionKey: "Multiple nested relationships not yet supported with relation type \(RelationType.Embedding)"])
+            let error = CoreDataKitError.UnimplementedMethod(description: "Multiple nested relationships not yet supported with relation type \(RelationType.Embedding)")
             throw error
 
         case .Some(_):
-            let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.UnimplementedMethod.rawValue, userInfo: [NSLocalizedDescriptionKey: "Referenced relationships are not supported with relation type \(RelationType.Embedding)"])
+            let error = CoreDataKitError.UnimplementedMethod(description: "Referenced relationships are not supported with relation type \(RelationType.Embedding)")
             throw error
 
         case .Null:
@@ -237,7 +236,7 @@ extension NSManagedObject
                     objectSet.removeAllObjects()
                 }
             } else {
-                let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.RelationshipPropertyNotFound.rawValue, userInfo: [NSLocalizedDescriptionKey: "Can't append imported object to to-many relation '\(entity.name).\(relationship.name)' because it's not a NSMutableSet"])
+                let error = CoreDataKitError.ImportError(description: "Can't append imported object to to-many relation '\(entity.name).\(relationship.name)' because it's not a NSMutableSet")
                 throw error
             }
         } else {
@@ -256,7 +255,7 @@ extension NSManagedObject
             } else if (relationship.optional) {
                 setValue(nil, forKeyPath: relationship.name)
             } else {
-                let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.InvalidPropertyConfiguration.rawValue, userInfo: [NSLocalizedDescriptionKey: "Relationship \(self.entity.name).\(relationship.name) is not optional, cannot set to null"])
+                let error = CoreDataKitError.ImportError(description: "Relationship \(self.entity.name).\(relationship.name) is not optional, cannot set to null")
                 throw error
             }
         }

--- a/CoreDataKit/Importing/NSManagedObjectContext+Importing.swift
+++ b/CoreDataKit/Importing/NSManagedObjectContext+Importing.swift
@@ -45,11 +45,11 @@ extension NSManagedObjectContext
             return object
 
         case .Null:
-            let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.InvalidValue.rawValue, userInfo: [NSLocalizedDescriptionKey: "Value 'null' in import dictionary for identifying atribute '\(entityDescription.name).\(identifyingAttribute.name)', dictionary: \(dictionary)"])
+            let error = CoreDataKitError.ImportError(description: "Value 'null' in import dictionary for identifying atribute '\(entityDescription.name).\(identifyingAttribute.name)', dictionary: \(dictionary)")
             throw error
 
         case .None:
-            let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.InvalidValue.rawValue, userInfo: [NSLocalizedDescriptionKey: "No value in import dictionary for identifying atribute '\(entityDescription.name).\(identifyingAttribute.name)', dictionary: \(dictionary)"])
+            let error = CoreDataKitError.ImportError(description: "No value in import dictionary for identifying atribute '\(entityDescription.name).\(identifyingAttribute.name)', dictionary: \(dictionary)")
             throw error
         }
     }
@@ -89,7 +89,7 @@ extension NSManagedObjectContext
         let objects = try self.find(entityDescription, predicate: predicate)
 
         if objects.count > 1 {
-            let error = NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.UnexpectedNumberOfResults.rawValue, userInfo: [NSLocalizedDescriptionKey: "Expected 0...1 result, got \(objects.count) results"])
+            let error = CoreDataKitError.ImportError(description: "Expected 0...1 result, got \(objects.count) results")
             throw error
         }
 

--- a/CoreDataKit/NSPersistentStoreCoordinator.swift
+++ b/CoreDataKit/NSPersistentStoreCoordinator.swift
@@ -58,7 +58,7 @@ extension NSPersistentStoreCoordinator
         }
         else
         {
-            throw NSError(domain: CoreDataKitErrorDomain, code: CoreDataKitErrorCode.UnknownError.rawValue, userInfo: nil)
+            throw CoreDataKitError.UnknownError(description: "NSMangedObjectModel should be available")
         }
     }
 
@@ -81,7 +81,12 @@ extension NSPersistentStoreCoordinator
                 NSSQLitePragmasOption: ["journal_mode": "WAL"]
             ];
 
-            try self.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: URL, options: options)
+            do {
+                try self.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: URL, options: options)
+            }
+            catch let error as NSError {
+                throw CoreDataKitError.CoreDataError(error)
+            }
         }
 
         do {

--- a/CoreDataKitTests/Importing/NSManagedObject+ImportingTests.swift
+++ b/CoreDataKitTests/Importing/NSManagedObject+ImportingTests.swift
@@ -21,8 +21,8 @@ class NSManagedObjectTests: TestCase {
             do {
                 let result = try coreDataStack.rootContext.importEntity(EmployeeImportable.self, dictionary: jsonObject)
 
-                XCTAssertEqual(result.name, jsonObject["checkName"] as! String, "Unexpected name")
-                XCTAssertEqual(result.age, jsonObject["checkAge"] as! Int, "Unexpected age")
+                XCTAssertEqual(result.name, jsonObject["checkName"] as? String, "Unexpected name")
+                XCTAssertEqual(result.age, jsonObject["checkAge"] as? Int, "Unexpected age")
             }
             catch {
                 XCTFail("Unexpected error")

--- a/CoreDataKitTests/NSManagedObjectContextTests.swift
+++ b/CoreDataKitTests/NSManagedObjectContextTests.swift
@@ -80,7 +80,7 @@ class NSManagedObjectContextTests: TestCase {
                 try result()
                 XCTFail("Expected error")
             }
-            catch let error as NSError {
+            catch CoreDataKitError.CoreDataError(let error) {
                 XCTAssertEqual(error.code, 1570, "Incorrect error code")
                 XCTAssertEqual(self.coreDataStack.rootContext.countForFetchRequest(countFRq, error: nil), 0, "Unexpected employee entities")
                 completionExpectation.fulfill()
@@ -147,9 +147,8 @@ class NSManagedObjectContextTests: TestCase {
             try coreDataStack.rootContext.create(EmployeeIncorrectEntityName.self)
             XCTFail("Unexpected managed object")
         }
-        catch let error as NSError {
-            XCTAssertEqual(error.domain, CoreDataKitErrorDomain, "Unexpected error domain")
-            XCTAssertEqual(error.code, CoreDataKitErrorCode.EntityDescriptionNotFound.rawValue, "Unexpected error code")
+        catch CoreDataKitError.ContextError {
+            // Expected error
         }
         catch {
           XCTFail("Unexpected error")


### PR DESCRIPTION
Instead of using throwing opaque NSErrors, use CoreDataKitError.
This makes errors more obvious and issues more easily be debugged.

Two properties have been added for backward compatibility:
`CoreDataKitError.nsError` for creating NSErrors, and
`NSError.coreDataKitError` for getting a CoreDataKitError back out of an
NSError.