### PR TITLE
Default implemetation of NamedManagedObject added

### DIFF
--- a/CoreDataKit/NamedManagedObject.swift
+++ b/CoreDataKit/NamedManagedObject.swift
@@ -7,7 +7,22 @@
 //
 
 /// Protocol that enables CoreDataKit to handle entities based on a
+
+import Foundation
+
 public protocol NamedManagedObject: class {
     /// The name of the entity as it is known in the managed object model
     static var entityName: String { get }
+}
+
+extension NamedManagedObject {
+    
+    static var entityName: String {
+        let classString = NSStringFromClass(self)
+        // The entity is the last component of dot-separated class name:
+        let components = classString.characters.split{ $0 == "." }.map { String($0) }
+        assert(components.count > 0, "Failed extract class name from \(classString)")
+        return components.last!
+    }
+    
 }


### PR DESCRIPTION
Non need to add manually the definition of "entityName" property in each NSManagedObject subclass. Now it can be retrieved directly from NSManagedObject subclass's name